### PR TITLE
Capturada la excepción del empleado sin turnos

### DIFF
--- a/src/WebApplication1/Controllers/AppointmentController.cs
+++ b/src/WebApplication1/Controllers/AppointmentController.cs
@@ -153,7 +153,15 @@ namespace API.Controllers
         [HttpGet("[action]/{providerId}")]
         public ActionResult<List<AllApointmentsOfMyShopRequestDTO?>> GetAllApointmentsByProviderId([FromRoute] int providerId)
         {
-            return _appointmentService.GetAllAppointmentsByProviderId(providerId);
+            try
+            {
+                return _appointmentService.GetAllAppointmentsByProviderId(providerId);
+            }
+            catch (Exception ex)
+            {
+                return NotFound(ex);
+            }
+            
         }
     }
 }


### PR DESCRIPTION
En la sección del dueño, si se filtraban los turnos por un empleado nuevo que aun no posee turnos asignados se arrojaba una excepción no controlada. Se contempló y se corrigió eso.